### PR TITLE
Preserve pagination across navigation + page limit after delete

### DIFF
--- a/apps/web/src/components/transactionstable/TransactionTable.jsx
+++ b/apps/web/src/components/transactionstable/TransactionTable.jsx
@@ -15,9 +15,19 @@ import Pagination from "./Pagination";
 import BulkActions from "./BulkActions";
 
 const TransactionTable = () => {
-	const { dashboardSortState, setDashboardSortState, filters, setFilters, setNotification } = useDataStore((state) => ({
+	const {
+		dashboardSortState,
+		setDashboardSortState,
+		dashboardPage,
+		setDashboardPage,
+		filters,
+		setFilters,
+		setNotification,
+	} = useDataStore((state) => ({
 		dashboardSortState: state.dashboardSortState,
 		setDashboardSortState: state.setDashboardSortState,
+		dashboardPage: state.dashboardPage,
+		setDashboardPage: state.setDashboardPage,
 		totalTransactionCount: state.totalTransactionCount,
 		filters: state.filters,
 		setFilters: state.setFilters,
@@ -26,10 +36,10 @@ const TransactionTable = () => {
 
 	const tableRef = useRef(null);
 	const filtersRef = useRef(null);
+	const hasMountedRef = useRef(false);
 
 	const [selectedTransactionIds, setSelectedTransactionIds] = useState([]);
 	const [showFilters, setShowFilters] = useState(false);
-	const [page, setPage] = useState(0);
 	const pageSize = 20;
 
 	const { data: categories, isLoading: categoriesLoading } = useCategoriesQuery();
@@ -51,8 +61,8 @@ const TransactionTable = () => {
 	}, [transactions, dashboardSortState]);
 
 	const pagedTransactions = useMemo(() => {
-		return sortedTransactions.slice(page * pageSize, page * pageSize + pageSize);
-	}, [sortedTransactions, page]);
+		return sortedTransactions.slice(dashboardPage * pageSize, dashboardPage * pageSize + pageSize);
+	}, [sortedTransactions, dashboardPage]);
 
 	const selectedTransactions = useMemo(() => {
 		return transactions.filter((transaction) => selectedTransactionIds.includes(transaction.id));
@@ -65,9 +75,14 @@ const TransactionTable = () => {
 	const tableLocked =
 		!showInitialLoadingState && (updateTransactionCategoryMutation.isPending || dashboardDataFetching);
 
+	const pageLimit = useMemo(() => {
+		return Math.ceil(transactions?.length / pageSize) - 1;
+	}, [transactions]);
+
 	useEffect(() => {
-		setPage(0);
-	}, [filters]);
+		if (transactions.length > 0 && dashboardPage > Math.ceil(transactions?.length / pageSize) - 1)
+			setDashboardPage(pageLimit);
+	}, [transactions]);
 
 	// Resize the height of the filter menu on window resize
 	useLayoutEffect(() => {
@@ -95,7 +110,7 @@ const TransactionTable = () => {
 
 		syncAllPlaidItemsMutation.mutate(undefined, {
 			onSuccess: (items) => {
-				setNotification(formatPlaidSyncSuccessNotification(items))
+				setNotification(formatPlaidSyncSuccessNotification(items));
 			},
 		});
 	};
@@ -321,8 +336,8 @@ const TransactionTable = () => {
 						)}
 					</div>
 					<Pagination
-						page={page}
-						setPage={setPage}
+						page={dashboardPage}
+						setPage={setDashboardPage}
 						pageLimit={Math.ceil(transactions?.length / pageSize) - 1}
 					/>
 				</div>

--- a/apps/web/src/util/dataStore.js
+++ b/apps/web/src/util/dataStore.js
@@ -2,11 +2,27 @@ import { create } from "zustand";
 import { defaultFilter } from "../constants/Filters";
 
 const today = new Date();
+const DASHBOARD_PAGE_STORAGE_KEY = "dashboard_page";
+
+const getStoredDashboardPage = () => {
+	if (typeof window === "undefined") return 0;
+
+	const rawValue = window.sessionStorage.getItem(DASHBOARD_PAGE_STORAGE_KEY);
+	const parsedValue = Number(rawValue);
+
+	return Number.isInteger(parsedValue) && parsedValue >= 0 ? parsedValue : 0;
+};
+
+const setStoredDashboardPage = (page) => {
+	if (typeof window === "undefined") return;
+
+	window.sessionStorage.setItem(DASHBOARD_PAGE_STORAGE_KEY, String(page));
+};
 
 const store = (set) => ({
 	filters: [{ ...defaultFilter }],
 	setFilters: (filters) => {
-		set(() => ({ filters }));
+		set(() => ({ filters, dashboardPage: 0 }));
 	},
 	notification: null,
 	setNotification: (notification) => set(() => ({ notification })),
@@ -16,6 +32,12 @@ const store = (set) => ({
 
 	dashboardSortState: null,
 	setDashboardSortState: (state) => set(() => ({ dashboardSortState: state })),
+	dashboardPage: getStoredDashboardPage(),
+	setDashboardPage: (page) =>
+		set(() => {
+			setStoredDashboardPage(page);
+			return { dashboardPage: page };
+		}),
 
 	spendingYear: today.getFullYear(),
 	setSpendingYear: (year) => set(() => ({ spendingYear: year })),
@@ -30,9 +52,9 @@ const store = (set) => ({
 
 	editingMerchantSetting: null,
 	setEditingMerchantSetting: (merchantSetting) => set(() => ({ editingMerchantSetting: merchantSetting })),
-  scrollToNewMerchantSetting: false,
-  setScrollToNewMerchantSetting: (scroll) => set(() => ({ scrollToNewMerchantSetting: scroll })),
-  
+	scrollToNewMerchantSetting: false,
+	setScrollToNewMerchantSetting: (scroll) => set(() => ({ scrollToNewMerchantSetting: scroll })),
+
 	editingNotesTransaction: null,
 	setEditingNotesTransaction: (editingNotesTransaction) => set(() => ({ editingNotesTransaction })),
 


### PR DESCRIPTION
- Preserve pagination in Zustand so page is not reset in a specific use case like saving merchant and navigating back to the transactions table 
- Check on transactions state change if current page is greater than page limit, change current page equal page limit if so